### PR TITLE
Correctly update system PATH

### DIFF
--- a/scripts/linuxki_install
+++ b/scripts/linuxki_install
@@ -45,7 +45,7 @@ cp /opt/linuxki/man/man7/*.gz /usr/share/man/man7
 # 
 # add /opt/linuxki to the PATH variable
 # 
-echo "PATH=$PATH:/opt/linuxki" > /etc/profile.d/linuxki.sh
+echo 'export PATH=$PATH:/opt/linuxki' > /etc/profile.d/linuxki.sh
 
 #
 # If this install is on a cluster head node with pdsh installed then set


### PR DESCRIPTION
Update `linuxki_install` (which creates `/etc/profile.d/linuxki.sh`) so it appends
`/opt/linuxki` to the system `PATH`, rather than replacing the existing `PATH`, and
export the updated `PATH` so it is visible to the environment of the caller of
the `linuxki.sh` script.

Signed-off-by: Christopher Voltz <christopher@voltz.ws>