### PR TITLE
Add Docker container to support viewing HTML reports with visualizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# Licensed under GPL v2 or later
+#
+# See https://docs.docker.com/install/ for information on how to install Docker.
+#
+# After installing LinuxKI, build the container image:
+#   docker build \
+#     --tag linuxki \
+#     --build-arg http_proxy=$http_proxy \
+#     --build-arg https_proxy=$https_proxy \
+#     --build-arg HTTP_PROXY=$HTTP_PROXY \
+#     --build-arg HTTPS_PROXY=$HTTPS_PROXY \
+#     /opt/linuxki
+#
+# When generating the LinuxKI reports with kiall, add the -V option to enable
+# visualisations in the reports when possible.
+#
+# After the LinuxKI reports have been generated, to see the results with the
+# visualizations, from the directory with the analysis results, run:
+#   docker run \
+#     --detach \
+#     --name linuxki \
+#     --publish-all \
+#     --rm \
+#     --volume $PWD:/var/www/html/linuxki \
+#     linuxki
+#
+#   port=$(docker inspect \
+#     --format='{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' \
+#     linuxki)
+#   echo Server running on port $port
+#
+#   html_file=$(find . -iname 'kp.*.html')
+#   [[ $(echo $html_file | wc --words) -ne 1 ]] && unset html_file
+#   xdg-open http://localhost:$port/linuxki/$html_file
+#
+# When finished looking at the results, run:
+#   docker stop linuxki
+
+FROM centos:7
+LABEL maintainer="Christopher Voltz <christopher@voltz.ws>"
+
+RUN yum update -y
+RUN yum install -y yum-utils
+RUN yum install -y httpd mod_ssl
+RUN yum install -y http://rpms.remirepo.net/enterprise/remi-release-7.rpm && \
+  yum-config-manager --enable remi-php72 && \
+  yum install -y php php-opcache
+RUN yum install -y https://raw.githubusercontent.com/HewlettPackard/LinuxKI/master/rpms/linuxki-5.4-2.noarch.rpm
+RUN yum clean all -y && rm -rf /var/cache/yum
+
+RUN echo '<?php phpinfo(); ?>' > /var/www/html/info.php
+
+EXPOSE 80
+EXPOSE 443
+
+CMD /usr/sbin/httpd -DFOREGROUND

--- a/man/man1/kiall.1
+++ b/man/man1/kiall.1
@@ -55,6 +55,7 @@ LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1)
 kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1)
 kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1)
 kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki
 

--- a/man/man1/kiclean.1
+++ b/man/man1/kiclean.1
@@ -50,5 +50,6 @@ LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1)
 kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1)
 kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1)
 kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-clparse.1
+++ b/man/man1/kiinfo-clparse.1
@@ -83,6 +83,6 @@ Typically, the generation of the Cluster Overview Report will be managed through
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-dump.1
+++ b/man/man1/kiinfo-dump.1
@@ -95,6 +95,6 @@ Enable tracing only for certain subsystems.  Valid subsystems include: power, sc
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kiall.1
+++ b/man/man1/kiinfo-kiall.1
@@ -71,6 +71,6 @@ After executing, the following reports (and appropriate CSV files) will be gener
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kidock.1
+++ b/man/man1/kiinfo-kidock.1
@@ -109,6 +109,6 @@ Limit per-docker container details to list npids for each docker container
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kidsk.1
+++ b/man/man1/kiinfo-kidsk.1
@@ -298,6 +298,6 @@ Mapper Device Statistics
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-prof(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-prof(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kifile.1
+++ b/man/man1/kiinfo-kifile.1
@@ -170,6 +170,6 @@ Note that the Sleep Functions are only available if the LiKI tracing mechanism i
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kifutex.1
+++ b/man/man1/kiinfo-kifutex.1
@@ -123,6 +123,6 @@ Do not print syscall entry records when using kitrace flag
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kipid.1
+++ b/man/man1/kiinfo-kipid.1
@@ -384,6 +384,6 @@ PID 15572  /home/mcr/bin/iotest8
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kiprof.1
+++ b/man/man1/kiinfo-kiprof.1
@@ -262,6 +262,6 @@ Specify output of "db2pd -edus" to get DB2 thread names.
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kirunq.1
+++ b/man/man1/kiinfo-kirunq.1
@@ -156,6 +156,6 @@ Idle time in Usecs
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kisock.1
+++ b/man/man1/kiinfo-kisock.1
@@ -227,6 +227,6 @@ Do not print syscall entry records when using kitrace flag
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kitrace.1
+++ b/man/man1/kiinfo-kitrace.1
@@ -177,6 +177,6 @@ Fri Jun 12 08:57:16 2015
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kiwait.1
+++ b/man/man1/kiinfo-kiwait.1
@@ -164,6 +164,6 @@ Print formatted time for each records (ie.  Wed Feb  5 16:40:15.529100)
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-kparse.1
+++ b/man/man1/kiinfo-kparse.1
@@ -60,6 +60,6 @@ Specify output of "db2pd -edus" to get DB2 thread names.
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-likidump.1
+++ b/man/man1/kiinfo-likidump.1
@@ -143,6 +143,6 @@ gettimeofday
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-likimerge.1
+++ b/man/man1/kiinfo-likimerge.1
@@ -36,6 +36,6 @@ See kiinfo(1).
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo-live.1
+++ b/man/man1/kiinfo-live.1
@@ -61,6 +61,6 @@ Floating point time is seconds of the step interval
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kiinfo.1
+++ b/man/man1/kiinfo.1
@@ -184,7 +184,7 @@ using the current timestamp:
 Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki
 

--- a/man/man1/kivis-build.1
+++ b/man/man1/kivis-build.1
@@ -23,9 +23,31 @@ Must be run using
 .B sudo
 or by a user in the
 .B docker
-group. If the proxy environment variables (e.g.,
-.BR http_proxy )
-are set, they will be used when building the image.
+group.
+
+.SH ENVIRONMENT
+
+.B kivis-build
+supports proxies for HTTP and HTTPS when building the image. The
+.B yum
+commands used when building the container will use the following proxy environment variables:
+
+.RS
+.B http_proxy, https_proxy
+.RS
+If set, the
+.B http_proxy
+and
+.B https_proxy
+variables should contain the URL of the proxy for the HTTP and HTTPS connection respectively. For example:
+.B http://proxy.fqdn:8080
+.RE
+
+.B no_proxy
+.RS
+If set, this variable should contain a comma-separated list of domain extensions the proxy should not be used for. For example:
+.B localhost,127.0.0.1,.dev.net
+.RE
 
 .SH AUTHOR
 Christopher Voltz <christopher@voltz.ws>

--- a/man/man1/kivis-build.1
+++ b/man/man1/kivis-build.1
@@ -19,7 +19,11 @@ which is used by the LinuxKI visualization tools
 and
 .BR kivis-stop .
 
-Must be run by a user with sudo privileges. If the proxy environment variables (e.g.,
+Must be run using
+.B sudo
+or by a user in the
+.B docker
+group. If the proxy environment variables (e.g.,
 .BR http_proxy )
 are set, they will be used when building the image.
 

--- a/man/man1/kivis-build.1
+++ b/man/man1/kivis-build.1
@@ -4,19 +4,52 @@
 .ad l
 .TH kivis-build 1 "5.4 - April 18, 2018" version "5.4"
 .SH NAME
-kivis-build - Build the LinuxKI visualization Docker container
+kivis-build \- Build the LinuxKI visualization Docker image
 
 .SH SYNOPSIS
 .B kivis-build
 
 .SH DESCRIPTION
 
-\fBkivis-build\fR builds the Docker container \fBlinuxki\fR which is used by the LinuxKI visulization tools \fBkivis-start\fR and \fBkivis-stop\fR. Must be run by a user with sudo privileges. If the proxy environment variables (e.g., \fBhttp_proxy\fR) are set, they will be used when building the container.
+.B kivis-build
+builds the Docker image
+.B linuxki
+which is used by the LinuxKI visualization tools
+.B kivis-start
+and
+.BR kivis-stop .
+
+Must be run by a user with sudo privileges. If the proxy environment variables (e.g.,
+.BR http_proxy )
+are set, they will be used when building the image.
 
 .SH AUTHOR
 Christopher Voltz <christopher@voltz.ws>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
+.BR LinuxKI (1),
+.BR kiinfo-dump (1),
+.BR kiinfo-likidump (1),
+.BR kiinfo-likimerge (1),
+.BR kiinfo-live (1),
+.BR kiinfo-kparse (1),
+.BR kiinfo-kitrace (1),
+.BR kiinfo-kipid (1),
+.BR kiinfo-kiprof (1),
+.BR kiinfo-kidsk (1),
+.BR kiinfo-kirunq (1),
+.BR kiinfo-kiwait (1),
+.BR kiinfo-kifile (1),
+.BR kiinfo-kisock (1),
+.BR kiinfo-kifutex (1),
+.BR kiinfo-kidock (1),
+.BR kiinfo-kiall (1),
+.BR kiinfo-clparse (1),
+.BR runki (1),
+.BR kiall (1),
+.BR kiclean (1),
+.BR kivis-start (1),
+.BR kivis-stop (1)
 
-https://github.com/HewlettPackard/LinuxKI/wiki
+.UR https://github.com/HewlettPackard/LinuxKI/wiki
+.UE

--- a/man/man1/kivis-build.1
+++ b/man/man1/kivis-build.1
@@ -1,0 +1,22 @@
+.\" Process this file with
+.\" groff -man -Tascii kiinfo.1
+.\"
+.ad l
+.TH kivis-build 1 "5.4 - April 18, 2018" version "5.4"
+.SH NAME
+kivis-build - Build the LinuxKI visualization Docker container
+
+.SH SYNOPSIS
+.B kivis-build
+
+.SH DESCRIPTION
+
+\fBkivis-build\fR builds the Docker container \fBlinuxki\fR which is used by the LinuxKI visulization tools \fBkivis-start\fR and \fBkivis-stop\fR. Must be run by a user with sudo privileges. If the proxy environment variables (e.g., \fBhttp_proxy\fR) are set, they will be used when building the container.
+
+.SH AUTHOR
+Christopher Voltz <christopher@voltz.ws>
+
+.SH SEE ALSO
+LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
+
+https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kivis-start.1
+++ b/man/man1/kivis-start.1
@@ -13,8 +13,10 @@ kivis-start \- Starts the LinuxKI visualization Docker container
 
 .B kivis-start
 runs the Docker container
-.B linuxki
-and shows the hosted files in the default web browser. The container starts the Apache web server (with PHP extensions) which hosts the files in the current directory. After the container is started, the default browser is opened to show either the
+.IB $USER -linuxki
+(where
+.I $USER
+is replaced with the current username) and shows the hosted files in the default web browser. The container starts the Apache web server (with PHP extensions) which hosts the files in the current directory. After the container is started, the default browser is opened to show either the
 .B kp.*.html
 page (if there is only one in the current directory or subdirectories) or the files in the current directory.
 
@@ -31,7 +33,7 @@ When finished viewing the reports, run
 to stop the container.
 
 If the
-.B linuxki
+.IB $USER -linuxki
 container is already running, it will be stopped and a new container will be started.
 
 .SH USAGE

--- a/man/man1/kivis-start.1
+++ b/man/man1/kivis-start.1
@@ -4,39 +4,82 @@
 .ad l
 .TH kivis-start 1 "5.4 - April 18, 2018" version "5.4"
 .SH NAME
-kivis-start - Starts the LinuxKI visualization Docker container
+kivis-start \- Starts the LinuxKI visualization Docker container
 
 .SH SYNOPSIS
 .B kivis-start
 
 .SH DESCRIPTION
 
-\fBkivis-start\fR runs the Docker container \fBlinuxki\fR and shows the hosted files in the default web browser. The container starts the Apache web server (with PHP extensions) which hosts the files in the current directory. After the container is started, the default browser is opened to show either the \fBkp.*.html\fR page (if there is only one in the current directory or subdirectories) or the files in the current directory.
+.B kivis-start
+runs the Docker container
+.B linuxki
+and shows the hosted files in the default web browser. The container starts the Apache web server (with PHP extensions) which hosts the files in the current directory. After the container is started, the default browser is opened to show either the
+.B kp.*.html
+page (if there is only one in the current directory or subdirectories) or the files in the current directory.
 
-The command must be run from the directory containing the output of the \fBkiall\fR command. If the \fB-V\fR option is used when \fBkiall\fR is run, then the visualizations will be shown as well.
+The command must be run from the directory containing the output of the
+.B kiall
+command. If the
+.B -V
+option is used when
+.B kiall
+is run, then the visualizations will be shown as well.
 
-When finished viewing the reports, run \fBkivis-stop\fR to stop the container.
+When finished viewing the reports, run
+.B kivis-stop
+to stop the container.
 
-If the \fBlinuxki\fR container is already running, it will be stopped and a new container will be started.
+If the
+.B linuxki
+container is already running, it will be stopped and a new container will be started.
 
 .SH USAGE
 
 Generate the report, with visualizations:
-
+.RS
 .B $ kiall -r -V
+.RE
 
 Start the container:
-
+.RS
 .B $ kivis-start
+.RE
 
-Browser opens to show the report. When finished viewing the reports:
+Browser opens to show the report.
 
+When finished viewing the reports:
+.RS
 .B $ kivis-stop
+.RE
 
 .SH AUTHOR
 Christopher Voltz <christopher@voltz.ws>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
+.BR LinuxKI (1),
+.BR kiinfo-dump (1),
+.BR kiinfo-likidump (1),
+.BR kiinfo-likimerge (1),
+.BR kiinfo-live (1),
+.BR kiinfo-kparse (1),
+.BR kiinfo-kitrace (1),
+.BR kiinfo-kipid (1),
+.BR kiinfo-kiprof (1),
+.BR kiinfo-kidsk (1),
+.BR kiinfo-kirunq (1),
+.BR kiinfo-kiwait (1),
+.BR kiinfo-kifile (1),
+.BR kiinfo-kisock (1),
+.BR kiinfo-kifutex (1),
+.BR kiinfo-kidock (1),
+.BR kiinfo-kiall (1),
+.BR kiinfo-clparse (1),
+.BR runki (1),
+.BR kiall (1),
+.BR kiclean (1),
+.BR kivis-build (1),
+.BR kivis-stop (1)
 
-https://github.com/HewlettPackard/LinuxKI/wiki
+.UR https://github.com/HewlettPackard/LinuxKI/wiki
+.UE

--- a/man/man1/kivis-start.1
+++ b/man/man1/kivis-start.1
@@ -1,0 +1,42 @@
+.\" Process this file with
+.\" groff -man -Tascii kiinfo.1
+.\"
+.ad l
+.TH kivis-start 1 "5.4 - April 18, 2018" version "5.4"
+.SH NAME
+kivis-start - Starts the LinuxKI visualization Docker container
+
+.SH SYNOPSIS
+.B kivis-start
+
+.SH DESCRIPTION
+
+\fBkivis-start\fR runs the Docker container \fBlinuxki\fR and shows the hosted files in the default web browser. The container starts the Apache web server (with PHP extensions) which hosts the files in the current directory. After the container is started, the default browser is opened to show either the \fBkp.*.html\fR page (if there is only one in the current directory or subdirectories) or the files in the current directory.
+
+The command must be run from the directory containing the output of the \fBkiall\fR command. If the \fB-V\fR option is used when \fBkiall\fR is run, then the visualizations will be shown as well.
+
+When finished viewing the reports, run \fBkivis-stop\fR to stop the container.
+
+If the \fBlinuxki\fR container is already running, it will be stopped and a new container will be started.
+
+.SH USAGE
+
+Generate the report, with visualizations:
+
+.B $ kiall -r -V
+
+Start the container:
+
+.B $ kivis-start
+
+Browser opens to show the report. When finished viewing the reports:
+
+.B $ kivis-stop
+
+.SH AUTHOR
+Christopher Voltz <christopher@voltz.ws>
+
+.SH SEE ALSO
+LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
+
+https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kivis-start.1
+++ b/man/man1/kivis-start.1
@@ -55,6 +55,9 @@ When finished viewing the reports:
 .B $ kivis-stop
 .RE
 
+.SH NOTES
+Access to the web pages hosted by the container will be blocked by SELinux unless SELinux is in permissive mode or disabled.
+
 .SH AUTHOR
 Christopher Voltz <christopher@voltz.ws>
 

--- a/man/man1/kivis-stop.1
+++ b/man/man1/kivis-stop.1
@@ -1,0 +1,22 @@
+.\" Process this file with
+.\" groff -man -Tascii kiinfo.1
+.\"
+.ad l
+.TH kivis-stop 1 "5.4 - April 18, 2018" version "5.4"
+.SH NAME
+kivis-stop - Stop the LinuxKI visualization Docker container
+
+.SH SYNOPSIS
+.B kivis-stop
+
+.SH DESCRIPTION
+
+\fBkivis-stop\fR stops the Docker container \fBlinuxki\fR, which is used by the LinuxKI visulization tools. The container is only stopped if it is running so it is not an error to run this command when the container is not running.
+
+.SH AUTHOR
+Christopher Voltz <christopher@voltz.ws>
+
+.SH SEE ALSO
+LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
+
+https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man1/kivis-stop.1
+++ b/man/man1/kivis-stop.1
@@ -4,19 +4,46 @@
 .ad l
 .TH kivis-stop 1 "5.4 - April 18, 2018" version "5.4"
 .SH NAME
-kivis-stop - Stop the LinuxKI visualization Docker container
+kivis-stop \- Stop the LinuxKI visualization Docker container
 
 .SH SYNOPSIS
 .B kivis-stop
 
 .SH DESCRIPTION
 
-\fBkivis-stop\fR stops the Docker container \fBlinuxki\fR, which is used by the LinuxKI visulization tools. The container is only stopped if it is running so it is not an error to run this command when the container is not running.
+.B kivis-stop
+stops the Docker container
+.BR linuxki ,
+which is used by the LinuxKI visualization tools. The container is only stopped if it is running so it is not an error to run this command when the container is not running.
 
 .SH AUTHOR
 Christopher Voltz <christopher@voltz.ws>
 
 .SH SEE ALSO
-LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
+.BR LinuxKI (1),
+.BR kiinfo-dump (1),
+.BR kiinfo-likidump (1),
+.BR kiinfo-likimerge (1),
+.BR kiinfo-live (1),
+.BR kiinfo-kparse (1),
+.BR kiinfo-kitrace (1),
+.BR kiinfo-kipid (1),
+.BR kiinfo-kiprof (1),
+.BR kiinfo-kidsk (1),
+.BR kiinfo-kirunq (1),
+.BR kiinfo-kiwait (1),
+.BR kiinfo-kifile (1),
+.BR kiinfo-kisock (1),
+.BR kiinfo-kifutex (1),
+.BR kiinfo-kidock (1),
+.BR kiinfo-kiall (1),
+.BR kiinfo-clparse (1),
+.BR runki (1),
+.BR kiall (1),
+.BR kiclean (1),
+.BR kivis-build (1),
+.BR kivis-start (1),
+.BR kivis-stop (1)
 
-https://github.com/HewlettPackard/LinuxKI/wiki
+.UR https://github.com/HewlettPackard/LinuxKI/wiki
+.UE

--- a/man/man1/runki.1
+++ b/man/man1/runki.1
@@ -127,5 +127,6 @@ LinuxKI(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1)
 kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1)
 kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1)
 kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/man/man7/linuxki.7
+++ b/man/man7/linuxki.7
@@ -74,6 +74,20 @@ see kiclean(1) manpage
 see kiinfo(1) manpage
 .RE
 
+.B kivis-build
+.RS
+see kivis-build(1) manpage
+.RE
+
+.B kivis-start
+.RS
+see kivis-start(1) manpage
+.RE
+
+.B kivis-stop
+.RS
+see kivis-stop(1) manpage
+.RE
 
 .SH BUGS
 	
@@ -83,6 +97,6 @@ Mark C. Ray <mark.ray@hpe.com>
 
 .SH SEE ALSO
 
-kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1)
+kiinfo(1) kiinfo-dump(1) kiinfo-likidump(1) kiinfo-likimerge(1) kiinfo-live(1) kiinfo-kparse(1) kiinfo-kitrace(1) kiinfo-kipid(1) kiinfo-kiprof(1) kiinfo-kidsk(1) kiinfo-kirunq(1) kiinfo-kiwait(1) kiinfo-kifile(1) kiinfo-kisock(1) kiinfo-kifutex(1) kiinfo-kidock(1) kiinfo-kiall(1) kiinfo-clparse(1) runki(1) kiall(1) kiclean(1) kivis-build(1) kivis-start(1) kivis-stop(1)
 
 https://github.com/HewlettPackard/LinuxKI/wiki

--- a/scripts/kivis-build
+++ b/scripts/kivis-build
@@ -1,6 +1,12 @@
 #!/bin/bash
 #
 # Builds the linuxki Docker image which is used by kivis-start and kivis-stop.
+# We pass along the proxy environment variables during the build. This makes
+# the image less portable then it otherwise would be but is required to support
+# building the image with versions of Docker before 17.07.  For Docker versions
+# 17.07 and later, users are recommended to configure the Docker client to pass
+# the variables to containers automatically, as documented at
+# https://docs.docker.com/network/proxy/.
 
 cd /opt/linuxki
 docker build \

--- a/scripts/kivis-build
+++ b/scripts/kivis-build
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Builds the linuxki Docker image which is used by kivis-start and kivis-stop.
+
+cd /opt/linuxki
+sudo docker build \
+        --tag linuxki \
+        --build-arg http_proxy=$http_proxy \
+        --build-arg https_proxy=$https_proxy \
+        --build-arg HTTP_PROXY=$HTTP_PROXY \
+        --build-arg HTTPS_PROXY=$HTTPS_PROXY \
+        .

--- a/scripts/kivis-build
+++ b/scripts/kivis-build
@@ -3,7 +3,7 @@
 # Builds the linuxki Docker image which is used by kivis-start and kivis-stop.
 
 cd /opt/linuxki
-sudo docker build \
+docker build \
         --tag linuxki \
         --build-arg http_proxy=$http_proxy \
         --build-arg https_proxy=$https_proxy \

--- a/scripts/kivis-start
+++ b/scripts/kivis-start
@@ -8,6 +8,27 @@
 # container is already running, it will automatically be stopped before the new
 # one is started.
 
+#
+# Debian has a package called docker which provides a docker command which has
+# nothing to do with Docker containers. Debian provides the docker.io package
+# to provide Docker container support but it is outdated so tell users to
+# install Docker by following the documentation on the docker.com website.
+#
+
+if ! docker --help |& grep container &> /dev/null; then
+        cat <<EOF
+Wrong docker package installed. See the Docker website for information on how
+to install Docker for container support:
+  CentOS/RHEL: https://docs.docker.com/install/linux/docker-ce/centos/
+  Fedora:      https://docs.docker.com/install/linux/docker-ce/fedora/
+  Debian:      https://docs.docker.com/install/linux/docker-ce/debian/
+  Ubuntu:      https://docs.docker.com/install/linux/docker-ce/ubuntu/
+Make sure to follow the instructions in the "Optional Linux post-installation
+steps".
+EOF
+        exit 1
+fi
+
 kivis-stop
 
 docker run \

--- a/scripts/kivis-start
+++ b/scripts/kivis-start
@@ -3,10 +3,10 @@
 # Starts a linuxki Docker container, which hosts the files in the current
 # directory, and then opens the default browser to the the kp*.html file if
 # there is one or to the directory if there is more than one kp*.html file.
-# Note that the container is named linuxki so kivis-stop knows which container
-# to stop but this means that only one container can be run at a time so if a
-# container is already running, it will automatically be stopped before the new
-# one is started. Additionally, the Docker image will
+# Note that the container is named $USER-linuxki so kivis-stop knows which
+# container to stop but this means that only one container can be run at a
+# time, per user, so if a container is already running, it will automatically
+# be stopped before the new one is started. Additionally, the Docker image will
 # be built, it it hasn't already been.
 
 #
@@ -42,7 +42,7 @@ kivis-stop
 
 docker run \
         --detach \
-        --name linuxki \
+        --name $USER-linuxki \
         --publish-all \
         --rm \
         --volume $PWD:/var/www/html/linuxki \
@@ -50,7 +50,7 @@ docker run \
 
 port=$(docker inspect \
         --format='{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' \
-        linuxki)
+        $USER-linuxki)
 echo Server running on port $port
 
 html_file=$(find . -iname 'kp.*.html')

--- a/scripts/kivis-start
+++ b/scripts/kivis-start
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # Starts a linuxki Docker container, which hosts the files in the current
-# directory, and then opens the default browser to the the kp*.html file if
+# directory, and then opens the default browser to the kp*.html file if
 # there is one or to the directory if there is more than one kp*.html file.
 # Note that the container is named $USER-linuxki so kivis-stop knows which
 # container to stop but this means that only one container can be run at a
@@ -38,7 +38,15 @@ if ! docker image inspect linuxki &> /dev/null; then
         /opt/linuxki/kivis-build
 fi
 
+#
+# Stop the container if it is already running.
+#
+
 /opt/linuxki/kivis-stop
+
+#
+# Start the linuxki container $USER-linuxki.
+#
 
 docker run \
         --detach \
@@ -48,10 +56,20 @@ docker run \
         --volume $PWD:/var/www/html/linuxki \
         linuxki
 
+#
+# Display the port the container is running the web server on.
+#
+
 port=$(docker inspect \
         --format='{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' \
         $USER-linuxki)
 echo Server running on port $port
+
+#
+# Open the default web browser to the LinuxKI report if a single one exists in
+# the current directory or subdirectory othewise to the list of files in the
+# current directory.
+#
 
 html_file=$(find . -iname 'kp.*.html')
 [[ $(echo $html_file | wc --words) -ne 1 ]] && unset html_file

--- a/scripts/kivis-start
+++ b/scripts/kivis-start
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Starts a linuxki Docker container, which hosts the files in the current
+# directory, and then opens the default browser to the the kp*.html file if
+# there is one or to the directory if there is more than one kp*.html file.
+# Note that the container is named linuxki so kivis-stop knows which container
+# to stop but this means that only one container can be run at a time so if a
+# container is already running, it will automatically be stopped before the new
+# one is started.
+
+kivis-stop
+
+docker run \
+        --detach \
+        --name linuxki \
+        --publish-all \
+        --rm \
+        --volume $PWD:/var/www/html/linuxki \
+        linuxki
+
+port=$(docker inspect \
+        --format='{{(index (index .NetworkSettings.Ports "80/tcp") 0).HostPort}}' \
+        linuxki)
+echo Server running on port $port
+
+html_file=$(find . -iname 'kp.*.html')
+[[ $(echo $html_file | wc --words) -ne 1 ]] && unset html_file
+xdg-open http://localhost:$port/linuxki/$html_file

--- a/scripts/kivis-start
+++ b/scripts/kivis-start
@@ -38,7 +38,7 @@ if ! docker image inspect linuxki &> /dev/null; then
         /opt/linuxki/kivis-build
 fi
 
-kivis-stop
+/opt/linuxki/kivis-stop
 
 docker run \
         --detach \

--- a/scripts/kivis-start
+++ b/scripts/kivis-start
@@ -6,7 +6,8 @@
 # Note that the container is named linuxki so kivis-stop knows which container
 # to stop but this means that only one container can be run at a time so if a
 # container is already running, it will automatically be stopped before the new
-# one is started.
+# one is started. Additionally, the Docker image will
+# be built, it it hasn't already been.
 
 #
 # Debian has a package called docker which provides a docker command which has
@@ -27,6 +28,14 @@ Make sure to follow the instructions in the "Optional Linux post-installation
 steps".
 EOF
         exit 1
+fi
+
+#
+# Build the Docker image if it doesn't exist already.
+#
+
+if ! docker image inspect linuxki &> /dev/null; then
+        /opt/linuxki/kivis-build
 fi
 
 kivis-stop

--- a/scripts/kivis-stop
+++ b/scripts/kivis-stop
@@ -1,7 +1,9 @@
 #!/bin/bash
 #
-# Stops the linuxki Docker container, if it is running.
+# Stops the user's linuxki Docker container, if it is running.
 
-if docker ps -f name=linuxki | grep -q linuxki; then
-        docker stop linuxki
+container="$USER-linuxki"
+
+if docker ps -f name=$container | grep -q $container; then
+        docker stop $container
 fi

--- a/scripts/kivis-stop
+++ b/scripts/kivis-stop
@@ -1,0 +1,7 @@
+#!/bin/bash
+#
+# Stops the linuxki Docker container, if it is running.
+
+if docker ps -f name=linuxki | grep -q linuxki; then
+        docker stop linuxki
+fi

--- a/scripts/linuxki_install
+++ b/scripts/linuxki_install
@@ -43,13 +43,6 @@ cp /opt/linuxki/man/man1/*.gz /usr/share/man/man1
 cp /opt/linuxki/man/man7/*.gz /usr/share/man/man7
 
 #
-# If Docker is installed, build the Docker container.
-#
-if which docker &> /dev/null; then
-        /opt/linuxki/kivis-build
-fi
-
-#
 # If this install is on a cluster head node with pdsh installed then set
 # up for cluster installation
 #

--- a/scripts/linuxki_install
+++ b/scripts/linuxki_install
@@ -43,6 +43,13 @@ cp /opt/linuxki/man/man1/*.gz /usr/share/man/man1
 cp /opt/linuxki/man/man7/*.gz /usr/share/man/man7
 
 #
+# If Docker is installed, build the Docker container.
+#
+if which docker &> /dev/null; then
+        /opt/linuxki/kivis-build
+fi
+
+#
 # If this install is on a cluster head node with pdsh installed then set
 # up for cluster installation
 #

--- a/scripts/linuxki_remove
+++ b/scripts/linuxki_remove
@@ -16,6 +16,20 @@
 . /opt/linuxki/config
 
 #
+# Stop the container if it is already running.
+#
+
+/opt/linuxki/kivis-stop
+
+#
+# Remove the Docker image if it exists.
+#
+
+if docker image inspect linuxki &> /dev/null; then
+	docker rmi --force linuxki
+fi
+
+#
 # Remove module(s)
 #
 echo -e \\tRemoving LiKI kernel module\(s\) ...


### PR DESCRIPTION
## Description
* Add ``Dockerfile`` and scripts to build a [Docker](https://docs.docker.com/install/linux/docker-ce/centos/) container image and start and stop a Docker container so users can easily view the HTML reports, including those with visualizations.
* Add ``man`` pages for the new scripts.
* Update the **SEE ALSO** section of the existing ``man`` pages to reference the new scripts.
* Update the LinuxKI installation script to automatically build the container image if Docker is already installed. 

The Docker container exposes ports 80 and 443 but the SSL certificate is self-signed so the user must add an exception for the certificate if HTTPS is used. The ``kivis-start`` script starts a container with the exposed ports on random ports to prevent conflicts. It looks up the port mapped to the exposed port 80 and opens the default browser using that port so the user doesn't need to worry about which port is actually being used. The random ports which the exposed ports are mapped to can be discovered using the standard docker commands (e.g., ``docker ps``, ``docker inspect``, ``docker port``) but the ``kivis-start`` script outputs the port mapping.

The Docker container image and container which are managed by the ``kivis-*`` scripts are called ``linuxki``. This makes it easy for a user to use the scripts without having to specify the container image name or container name but it also prevents more than one container from being used at a time.  The ``kivis-start`` script will automatically stop any existing container before starting a new one. Containers are automatically removed when they are stopped.

It is also possible to create the Docker container image and create and destroy containers directly from the provided ``Dockerfile`` using Docker commands, for those who are familiar with them. The ``kivis-*`` commands are simple wrappers around the Docker commands for those who aren't familiar with Docker or who just want a simple and short command to view the HTML reports.

## Typical usage

### Build the container image
The container image only needs to be built once. If the container image was not built at install time, run:
```
kivis-build
```

### Generate the HTML report
Generate the HTML reports as usual. For example:
```
kiall -r -V
```

### View the report
To view the reports, from the directory containing the reports (or a parent directory), run:
```
kivis-start
```
The default browser will automatically be opened to the report if there is a single one in the current directory or its subdirectories. If there is more than one report, the browser will be opened to a page which provides a directory listing which the user can navigate to select the desired report.

When finished viewing the report, run:
```
kivis-stop
```