### PR TITLE
fix kiinfo-kipid manpage: remove symlookup which is not supported

### DIFF
--- a/man/man1/kiinfo-kipid.1
+++ b/man/man1/kiinfo-kipid.1
@@ -154,11 +154,6 @@ Print formatted time for each records (ie.  Wed Feb  5 16:40:15.529100)
 Do not print syscall entry records when using kitrace flag 
 .RE
 
-.B symlookup
-.RS
-For live tracing, performs USER hardclock symbol table lookups
-.RE
-
 .B sysignore=<ignore_filee>
 .RS
 Do not trace system calls listed in the <ignore_file>. This can reduce trace data by eliminating frequently called system calls, such as getrusage(),gettimeofday(), time(), etc...


### PR DESCRIPTION
kiinfo -kipid doesn't recognize symlookup option, but its man page i.e. kiinfo-kipid(1) documented it.

The following doesn't work:
# kiinfo -kipid pid=14503,scdetail,symlookup -a 30 -p 1
Error: Invalid flag or trace file
...

The following works:
# kiinfo -kipid pid=14503,scdetail -a 30 -p 1

Signed-off-by: wenbinzeng <wenbin_zeng@hotmail.com>