### PR TITLE
Update kivis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN yum update -y
 RUN yum install -y yum-utils
 RUN yum install -y httpd mod_ssl
 RUN yum install -y http://rpms.remirepo.net/enterprise/remi-release-7.rpm && \
-  yum-config-manager --enable remi-php72 && \
+  yum-config-manager --enable remi-php73 && \
   yum install -y php php-opcache
 RUN yum install -y https://raw.githubusercontent.com/HewlettPackard/LinuxKI/master/rpms/linuxki-5.9-1.noarch.rpm
 RUN yum clean all -y && rm -rf /var/cache/yum

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,7 @@ RUN yum install -y httpd mod_ssl
 RUN yum install -y http://rpms.remirepo.net/enterprise/remi-release-7.rpm && \
   yum-config-manager --enable remi-php72 && \
   yum install -y php php-opcache
-RUN yum install -y https://raw.githubusercontent.com/HewlettPackard/LinuxKI/master/rpms/linuxki-5.5-1.noarch.rpm
+RUN yum install -y https://raw.githubusercontent.com/HewlettPackard/LinuxKI/master/rpms/linuxki-5.9-1.noarch.rpm
 RUN yum clean all -y && rm -rf /var/cache/yum
 
 RUN echo '<?php phpinfo(); ?>' > /var/www/html/info.php

--- a/scripts/kivis-start
+++ b/scripts/kivis-start
@@ -73,4 +73,4 @@ echo Server running on port $port
 
 html_file=$(find . -iname 'kp.*.html')
 [[ $(echo $html_file | wc --words) -ne 1 ]] && unset html_file
-xdg-open http://localhost:$port/linuxki/$html_file
+gio open http://localhost:$port/linuxki/$html_file


### PR DESCRIPTION
This pull request contains updates to the `kivis` functionality:
1. Update the Docker container to use the latest version of LinuxKI. The current version wasn't updated when later releases were made. The `Dockerfile` needs to be updated for _each_ release until there is a permanent link available that will always point to the latest released version. I recommend updating the packaging scripts to automatically update the `Dockerfile` so this problem won't recur.
1. Update the Docker container to use PHP 7.3 (the latest version) to get the latest bug and security fixes.
1. Update the `kivis-start` script to use `gio`, since `xdg-start` is deprecated.