### PR TITLE
adding "%%i" to allow spaces in windows folders

### DIFF
--- a/winki/convertpdb.cmd
+++ b/winki/convertpdb.cmd
@@ -1,1 +1,1 @@
-@for /r %%i in (*.pdb) do .\pdbdump.exe %%i >%%~ni.txt
+@for /r %%i in (*.pdb) do .\pdbdump.exe "%%i" >%%~ni.txt


### PR DESCRIPTION
"" is required to use folders with spaces like OneDrive