### PR TITLE
fix SecureBoot detection

### DIFF
--- a/scripts/module_prep
+++ b/scripts/module_prep
@@ -18,7 +18,7 @@ PATH=$PATH:/usr/sbin:/sbin:/usr/bin
 #
 # Liki DLKM tracing module cannot be used with SecureBoot.
 #
-if [ "`mokutil --sb-state >/dev/null 2>&1`" == "SecureBoot enabled" ]; then
+if [ "`mokutil --sb-state 2>&1`" == "SecureBoot enabled" ]; then
         echo
         echo "ERROR: SecureBoot enabled! Liki DLKM tracing module cannot be used with SecureBoot"
         echo You may still be able to use LinuxKI with ftrace mode:


### PR DESCRIPTION
SecureBoot detection in module_prep scrips is currently broken. The output of "mokutil --sb-state" is suppressed completely by redirecting to /dev/null.