### PR TITLE
Proposing a new -Z option which would leverage a parallel gzip tool (…

### DIFF
--- a/scripts/kiall
+++ b/scripts/kiall
@@ -63,7 +63,7 @@ shopt -s extglob
 # 
 # USAGE: 
 #
-#   kiall [-l] [-m] [-r] [-f] [-c] [-x] [-M] [-B] [-V] [-P num_threads] [-t timestamp]
+#   kiall [-l] [-m] [-r] [-f] [-c] [-x] [-Z] [-M] [-B] [-V] [-P num_threads] [-t timestamp]
 #   
 # OPTIONS:
 #  
@@ -84,6 +84,8 @@ shopt -s extglob
 #   -l        lite collection 
 #
 #   -x        Generate the kparse report as a .txt file instead of an .html file
+#
+#   -Z        Use parallel gzip/gunzip to speed up gzip/gunzip phases
 #
 #   -M        Leave C++ function names mangled
 #
@@ -119,10 +121,16 @@ hthr=""
 lite=0
 dotxt=0
 dovis=0
+dopigz=0
+dounpigz=0
+# defining GZIP/GUNZIP variables to minimize code changes to support
+# parallel gzip/gunzip with still decent code readability
+GZIP=gzip
+GUNZIP=gunzip
 
 help()
 {
-    printf "Usage: %s: [-l] [-m] [-r] [-f] [-c] [-x] [-M] [-B] [-t timestamp]\n" "$0"
+    printf "Usage: %s: [-l] [-m] [-r] [-f] [-c] [-x] [-Z] [-M] [-B] [-t timestamp]\n" "$0"
 	printf "       -h               Help\n"
 	printf "       -l               Lite version - bypasses some options\n" 
 	printf "       -m               Do not process collectl or MWA data\n"
@@ -130,6 +138,7 @@ help()
 	printf "       -f               Find KI files in pwd and any directories below\n"
 	printf "       -c               Cluster-wide processing\n"
 	printf "       -x               Generate Kparse text format instead of html format\n"
+	printf "       -Z               Use parallel gzip/gunzip to speed up gzip/gunzip phase\n"
 	printf "       -M               Leave C++ function names mangled\n"
 	printf "       -B               Do not report Disk Block Frequency stats in Kparse output\n"
 	printf "       -t <timestamp>   Only process KI bundle with matching timestamp\n"
@@ -154,8 +163,8 @@ extract_ki_files()
 # First, unzip regular files; not tar archives 
     for file in `ls *$tag*gz 2>/dev/null | grep -E -v "\.tar|\.tgz"`
     do
-        echo gunzip $file
-        gunzip $file
+        echo ${GUNZIP} $file
+        ${GUNZIP} $file
     done
 
 # Check to see if ki.bin or etl files exist.   If so, then we can return 
@@ -171,23 +180,32 @@ extract_ki_files()
 
 # if there are no ki.bin files, then try to extract from ki_all tar files 
     if [ -f ki_all.$NODENAME.$tag.tar ] ; then
-	gzip ki_all.$NODENAME.$tag.tar
+	${GZIP} ki_all.$NODENAME.$tag.tar
     fi 
     if [ -f ki_all.$NODENAME.$tag.tar.gz ] ; then
 	mv ki_all.$NODENAME.$tag.tar.gz ki_all.$NODENAME.$tag.tgz
     fi 
     if [ -f ki_all.$tag.tar ] ; then
-	gzip ki_all.$tag.tar
+	${GZIP} ki_all.$tag.tar
     fi 
     if [ -f ki_all.$tag.tar.gz ] ; then
 	mv ki_all.$tag.tar.gz ki_all.$NODENAME.$tag.tgz
     fi 
 
-    if [ -f ki_all.$NODENAME.$tag.tgz ] ; then
-	tar xf ki_all.$NODENAME.$tag.tgz
-    elif [ -f ki_all.$tag.tgz ] ; then
-	tar xf ki_all.$tag.tgz
+    if [ $dounpigz -eq 1 ] ; then
+        if [ -f ki_all.$NODENAME.$tag.tgz ] ; then
+	    cat ki_all.$NODENAME.$tag.tgz | unpigz -c - | tar -xf -
+        elif [ -f ki_all.$tag.tgz ] ; then
+	    cat ki_all.$tag.tgz | unpigz -c - | tar -xf -
+        fi
+    else
+        if [ -f ki_all.$NODENAME.$tag.tgz ] ; then
+	    tar xf ki_all.$NODENAME.$tag.tgz
+        elif [ -f ki_all.$tag.tgz ] ; then
+	    tar xf ki_all.$tag.tgz
+        fi
     fi
+
 
 # Check for Windows ZIP file 
     if [ -f ki_all.$NODENAME.$tag.zip ] ; then
@@ -244,7 +262,7 @@ process_mw()
     fi
 
     if [ -f MWA.tar.$tag ] ; then
-	gzip MWA.tar.$tag
+	${GZIP} MWA.tar.$tag
 	mv MWA.tar.$tag.gz MWA.$tag.tgz
     fi
 
@@ -557,6 +575,10 @@ while [ "`echo $1 | cut -c1`" = "-" ] ; do
 		-V)	dovis=1
 			shift 1
 			;;
+		-Z)	dopigz=1
+			dounpigz=1
+			shift 1
+			;;
 		-M)	mangle=",mangle"
 			shift 1
 			;;
@@ -604,6 +626,28 @@ fi
 if [ $cflag -eq 1 -a $fflag -eq 1 ] ; then
     echo "ERROR: Cannot use both -c and -f options"
     exit 11 
+fi
+
+if [ $dounpigz -eq 1 ] ; then
+    which unpigz >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "!!! parallel gunzip was requested (-Z) but the executable (unpigz) is not available"
+        echo "!!! falling back onto regular gunzip"
+        dounpigz=0
+    else
+        GUNZIP=unpigz
+    fi
+fi
+
+if [ $dopigz -eq 1 ] ; then
+    which pigz >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "!!! parallel gzip was requested (-Z) but the executable (pigz) is not available"
+        echo "!!! falling back onto regular gzip"
+        dopigz=0
+    else
+        GZIP=pigz
+    fi
 fi
 
 if [ $rflag -eq 1 ] ; then

--- a/scripts/kiclean
+++ b/scripts/kiclean
@@ -33,7 +33,7 @@
 # 
 # USAGE:
 # 
-#   kiclean [-r] [-f] [-p] [-v]
+#   kiclean [-r] [-f] [-p] [-v] [-Z]
 #
 # OPTIONS:  
 # 
@@ -48,6 +48,8 @@
 #
 #   -v       Remove the Visualization subdirs & related .sh .php .csv files
 #  
+#   -Z       Use parallel gzip/gunzip to speed up gzip/gunzip phases
+#
 # NOTE:
 #
 #   Update the DIR environment variable below to reflect the directory where the KI tools
@@ -60,12 +62,19 @@ force=0
 rflag=0
 pflag=0
 vflag=0
+dopigz=0
+dounpigz=0
+# defining GZIP/GUNZIP variables to minimize code changes to support
+# parallel gzip/gunzip with still decent code readability
+GZIP=gzip
+GUNZIP=gunzip
 
 help()
 {
-    printf "Usage: %s: [-r] [-f] [-p]\n" "$0"
+    printf "Usage: %s: [-r] [-f] [-p] [-Z]\n" "$0"
         printf "            -h               Help\n"
         printf "            -r               Recursively traverse subdirs looking for KI data to archive\n"
+        printf "            -Z               Use parallel gzip/gunzip to speed up gzip/gunzip phase\n"
 	printf "	    -p		     Remove PIDS and CIDS subdirectories\n"
         printf "            -f               Force remove misc/tmp files\n"
 }
@@ -91,7 +100,7 @@ clean_pwd()
 
 	if [ -z $NODENAME ]; then
 # 	    if there is no NODENAME, then pull it from the hostname file
-	    gunzip hostname.$tag >/dev/null 2>&1
+	    ${GUNZIP} hostname.$tag >/dev/null 2>&1
             if [ -f hostname.$tag ] ; then
                 NODENAME=`cat hostname.$tag | sed "s/\./ /g" | awk '{print $1}'`
             fi
@@ -106,16 +115,16 @@ clean_pwd()
 #	We will check the Windows KI zip file first
 	if [ ! -f ki_all.$NODENAME.$tag.zip ]; then
 	    if [ -f ki_all.$NODENAME.$tag.tar ] ; then
-               gzip ki_all.$NODENAME.$tag.tar
+               ${GZIP} ki_all.$NODENAME.$tag.tar
   	    fi
 	    if [ -f ki_all.$NODENAME.$tag.tar.gz ] ; then
 		mv ki_all.$NODENAME.$tag.tar.gz ki_all.$NODENAME.$tag.tgz
 	    fi
 	    if [ -f ki_all.$tag.tar ] ; then 
-		gzip ki_all.$tag.tar
+		${GZIP} ki_all.$tag.tar
 	    fi
 	    if [ -f ki_all.$NODENAME.$tag.tar ] ; then
-                gzip ki_all.$NODENAME.$tag.tar
+                ${GZIP} ki_all.$NODENAME.$tag.tar
             fi
             if [ -f ki_all.$NODENAME.$tag.tar.gz ] ; then
                 mv ki_all.$NODENAME.$tag.tar.gz ki_all.$NODENAME.$tag.tgz
@@ -124,8 +133,12 @@ clean_pwd()
 	    if [ ! -f ki_all.$NODENAME.$tag.tgz ] ; then
 #	        if there is no ki_all.*.tgz file, then lets archive what we have
 #    	        First, unzip regular files
-                gunzip *.gz
-	        tar -czvf ki_all.$NODENAME.$tag.tgz *.$tag	
+                ${GUNZIP} *.gz
+                if [ $dopigz -eq 1 ] ; then
+	            tar -cvf - *.$tag | pigz -c - > ki_all.$NODENAME.$tag.tgz
+                else
+	            tar -czvf ki_all.$NODENAME.$tag.tgz *.$tag
+                fi
 	    fi
 
 	    if [ ! -f ki_all.$NODENAME.$tag.tgz ] ; then
@@ -197,10 +210,34 @@ do
 		r)	rflag=1;;
 		p)	pflag=1;;
 		v)	vflag=1;;
+		Z)	dopigz=1
+			dounpigz=1;;
 		?)	help
 			exit 2;;
 	esac
 done
+
+if [ $dounpigz -eq 1 ] ; then
+    which unpigz >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "!!! parallel gunzip was requested (-Z) but the executable (unpigz) is not available"
+        echo "!!! falling back onto regular gunzip"
+        dounpigz=0
+    else
+        GUNZIP=unpigz
+    fi
+fi
+
+if [ $dopigz -eq 1 ] ; then
+    which pigz >/dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "!!! parallel gzip was requested (-Z) but the executable (pigz) is not available"
+        echo "!!! falling back onto regular gzip"
+        dopigz=0
+    else
+        GZIP=pigz
+    fi
+fi
 
 if [ $rflag -eq 1 ] ; then
 	recursive_clean

--- a/scripts/kiclean
+++ b/scripts/kiclean
@@ -201,7 +201,7 @@ recursive_clean()
 	done
 }
 
-while getopts hfpvr optname 
+while getopts hfpvrZ optname 
 do
 	case $optname in
 		h)	help

--- a/scripts/runki
+++ b/scripts/runki
@@ -680,7 +680,11 @@ getcollectldata()
 	   echo "=== Copying Collectl logs ... " | tee -a ki.err.$tag
 	   cd /var/log/collectl
            cp -p /etc/collectl.conf collectl.conf.$tag
-   	   tar -czf $KIDIR/collectl.$tag.tgz collectl.conf.$tag `find . -mtime -1|grep raw`
+           if [ $do_pgzip -eq 1 ] ; then
+               tar -cf - collectl.conf.$tag `find . -mtime -1|grep raw` | pigz -c - > $KIDIR/collectl.$tag.tgz
+           else
+               tar -czf $KIDIR/collectl.$tag.tgz collectl.conf.$tag `find . -mtime -1|grep raw`
+           fi
            rm -f collectl.conf.$tag
 	   cd $KIDIR
 	fi
@@ -689,7 +693,11 @@ getcollectldata()
 	       echo "=== Copying MeasureWare logs ... " | tee -a ki.err.$tag
 	       cd /var/opt/perf/datafiles
                cp ../parm parm.$tag
-   	       tar -czf $KIDIR/MW.$tag.tgz parm.$tag log*
+               if [ $do_pgzip -eq 1 ] ; then
+                   tar -cf - parm.$tag log* | pigz -c - > $KIDIR/MW.$tag.tgz
+               else
+                   tar -czf $KIDIR/MW.$tag.tgz parm.$tag log*
+               fi
                rm -f parm.$tag
 	       cd $KIDIR
 	   fi

--- a/scripts/runki
+++ b/scripts/runki
@@ -41,6 +41,7 @@ declare -a cpu_cstate
 
 duration=20
 do_local=0
+do_pgzip=0
 do_collectl=0
 do_userspace=0
 do_sar=0
@@ -59,9 +60,10 @@ MSRARG="nop"
 
 help()
 {
-	printf "Usage: %s: [-h] [-L] [-M] [-U] [-X] [-a] [-j] [-J path] [-f | -p] [-n interface] [-v] [-d duration] [-t maxrun] [-P pid] [-G tgid] [-C cpu] [-D dev] [-e event] [-s subsys] [-I sysignore] [-T timestamp] [-c \"comment\"]\n" "$0"
+	printf "Usage: %s: [-h] [-L] [-Z] [-M] [-U] [-X] [-a] [-j] [-J path] [-f | -p] [-n interface] [-v] [-d duration] [-t maxrun] [-P pid] [-G tgid] [-C cpu] [-D dev] [-e event] [-s subsys] [-I sysignore] [-T timestamp] [-c \"comment\"]\n" "$0"
 	printf "                -h              Help\n"
         printf "                -L              Gather minimal data for local analysis...no gzip/tar\n"
+        printf "                -Z              Use parallel gzip to speed up gzip/tar phase (NOT recommended on production systems)\n"
 	printf "                -M              Include Collectl/MeasureWare data collection\n"
         printf "                -U              Include userspace profile (perf) data collection\n"
         printf "                -X              Include sar data collection\n"
@@ -1071,6 +1073,7 @@ while true
 do
     case "$1" in
             -L)     do_local=1;;
+	    -Z)     do_pgzip=1;;
 	    -M)     do_collectl=1;;
             -m)     do_collectl=0;;
 	    -U)     do_userspace=1;;
@@ -1104,11 +1107,12 @@ do
 done
 
 ARGS=$cmdargs
-while getopts :d:t:hLMUXmuxpfajJ:n:e:s:V:T:P:G:C:D:I:F:Rc:v optname $ARGS
+while getopts :d:t:hLZMUXmuxpfajJ:n:e:s:V:T:P:G:C:D:I:F:Rc:v optname $ARGS
 do
     case $optname in
             h)     help;exit 2;;
             L)     do_local=1;;
+            Z)     do_pgzip=1;;
 	    M)     do_collectl=1;;
             m)     do_collectl=0;;
 	    U)     do_userspace=1;;
@@ -1149,6 +1153,15 @@ fi
 if [ $do_local -eq 1 ]; then
 	do_vxfs=0
 	do_collectl=0
+fi
+
+if [ $do_pgzip -eq 1 ]; then
+	which pigz >/dev/null 2>&1
+	if [ $? -ne 0 ]; then
+		echo "!!! parallel gzip was requested (-Z) but the executable (pigz) is not available"
+		echo "!!! falling back onto regular gzip"
+		do_pgzip=0
+	fi
 fi
 
 echo "=== $version" | tee -a ki.err.$tag
@@ -1550,18 +1563,35 @@ fi
 if [ $do_local -eq 0 ] ; then
 
     echo "=== Tarring up the results ... " | tee -a ki.err.$tag
-    # tar will gzip output via 'z' option
-    if [ -f collectl.$tag* ] && [ -f MW.$tag* ] ; then
-       tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag collectl.$tag* MW.$tag*
-    elif [ -f collectl.$tag* ] ; then
-       tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag collectl.$tag*
-    elif [ -f MW.$tag* ] ; then
-       tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag MW.$tag*
-    elif [ -f tcpdump.$tag* ] ; then
-	tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag tcpdump.$tag*
+
+    if [ $do_pgzip -eq 1 ] ; then
+        # tar will parallel gzip output via 'pigz' tool
+        if [ -f collectl.$tag* ] && [ -f MW.$tag* ] ; then
+           tar -cSf - *.$tag collectl.$tag* MW.$tag* | pigz -c - > ki_all.$HOSTNAME.$tag.tgz
+        elif [ -f collectl.$tag* ] ; then
+           tar -cSf - *.$tag collectl.$tag* | pigz -c - > ki_all.$HOSTNAME.$tag.tgz
+        elif [ -f MW.$tag* ] ; then
+           tar -cSf - *.$tag MW.$tag* | pigz -c - > ki_all.$HOSTNAME.$tag.tgz
+        elif [ -f tcpdump.$tag* ] ; then
+	   tar -cSf - *.$tag tcpdump.$tag* | pigz -c - > ki_all.$HOSTNAME.$tag.tgz
+        else
+           tar -cSf *.$tag | pigz -c - > ki_all.$HOSTNAME.$tag.tgz
+        fi
     else
-       tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag
+        # tar will gzip output via 'z' option
+        if [ -f collectl.$tag* ] && [ -f MW.$tag* ] ; then
+           tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag collectl.$tag* MW.$tag*
+        elif [ -f collectl.$tag* ] ; then
+           tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag collectl.$tag*
+        elif [ -f MW.$tag* ] ; then
+           tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag MW.$tag*
+        elif [ -f tcpdump.$tag* ] ; then
+	    tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag tcpdump.$tag*
+        else
+           tar -czSf ki_all.$HOSTNAME.$tag.tgz *.$tag
+        fi
     fi
+
     # remove the individual files
     rm -rf objdump.$tag 2>/dev/null
     rm -f *.$tag


### PR DESCRIPTION
… aka 'pigz' from RHEL8 BaseOS repo )

for a faster gzip/tar sequence

    On my 48-lcpu system (24c/48t), gzip/tar was taking more than 12 minutes with the standard tar -z option

    [root@cyrille-02 shm]# chrt -f 50 /opt/linuxki/runki | ts;
    Jan 14 14:50:24 === runki for Linux version 7.12
    Jan 14 14:50:25 === Getting Initial NUMA statistics information ...
    Jan 14 14:50:25 === Disabling TTWU_QUEUE scheduling feature ===
    Jan 14 14:50:25 === Installing Linux KI trace points ===
    Jan 14 14:50:25 === Starting: Linux KI LiKI trace dump for 20 seconds ===
    Jan 14 14:50:25 ===
    Jan 14 14:50:45 === LinuxKI LiKI dump complete  ===
    Jan 14 14:50:46 === KI trace complete.  Collecting supplemental files.
    Jan 14 14:50:46 === Enabling TTWU_QUEUE scheduling feature ===
    Jan 14 14:50:46 === Running lsof ...
    Jan 14 14:50:48 === Collecting task stack traces from /proc ...
    Jan 14 14:50:57 === Collecting task maps from /proc ...
    Jan 14 14:51:00 === Collecting task numa_maps from /proc ...
    Jan 14 14:51:04 === Collecting task cgroups from /proc ...
    Jan 14 14:51:06 === Collecting binary executable and library symbol table information ...
    Jan 14 14:51:06 === Getting Processor C-state information ...
    Jan 14 14:51:09 === Getting disk information ...
    Jan 14 14:51:09 === Building LVM mapping table ...
    Jan 14 14:51:09 === Collecting volume data ...
    Jan 14 14:51:10 === Gathering misc supporting data ...
    Jan 14 14:51:10 === Copying the syslog files ...
    Jan 14 14:51:14 === Getting Final NUMA statistics information ...
    Jan 14 14:51:22 === Tarring up the results ...
    Jan 14 15:03:45 === Trace completed and archived as ki_all.cyrille-02.0114_1450.tgz

    Using the proposed -Z implementation that does not use tar's built-in support for gzip but delegates the gzip phase to 'pigz', the 'Tarring up the results' phase now take ~30 seconds...
    [root@cyrille-02 shm]# chrt -f 50 /opt/linuxki/runki -Z | ts;
    Jan 14 18:48:01 === runki for Linux version 7.12
    Jan 14 18:48:02 === Getting Initial NUMA statistics information ...
    Jan 14 18:48:02 === Disabling TTWU_QUEUE scheduling feature ===
    Jan 14 18:48:02 === Installing Linux KI trace points ===
    Jan 14 18:48:02 === Starting: Linux KI LiKI trace dump for 20 seconds ===
    Jan 14 18:48:02 ===
    Jan 14 18:48:22 === LinuxKI LiKI dump complete  ===
    Jan 14 18:48:23 === KI trace complete.  Collecting supplemental files.
    Jan 14 18:48:23 === Enabling TTWU_QUEUE scheduling feature ===
    Jan 14 18:48:23 === Running lsof ...
    Jan 14 18:48:25 === Collecting task stack traces from /proc ...
    Jan 14 18:48:34 === Collecting task maps from /proc ...
    Jan 14 18:48:37 === Collecting task numa_maps from /proc ...
    Jan 14 18:48:41 === Collecting task cgroups from /proc ...
    Jan 14 18:48:43 === Collecting binary executable and library symbol table information ...
    Jan 14 18:48:43 === Getting Processor C-state information ...
    Jan 14 18:48:46 === Getting disk information ...
    Jan 14 18:48:46 === Building LVM mapping table ...
    Jan 14 18:48:46 === Collecting volume data ...
    Jan 14 18:48:46 === Gathering misc supporting data ...
    Jan 14 18:48:46 === Copying the syslog files ...
    Jan 14 18:48:51 === Getting Final NUMA statistics information ...
    Jan 14 18:48:59 === Tarring up the results ...
    Jan 14 18:49:32 === Trace completed and archived as ki_all.cyrille-02.0114_1848.tgz
